### PR TITLE
Updates to route protection logic

### DIFF
--- a/app/components/Admin/AdminLayout.jsx
+++ b/app/components/Admin/AdminLayout.jsx
@@ -1,6 +1,3 @@
-import { useEffect } from 'react';
-import { useRouter } from 'next/router';
-import { useUser } from '@auth0/nextjs-auth0';
 import Nav from 'react-bootstrap/Nav';
 import Navbar from 'react-bootstrap/Nav';
 
@@ -44,28 +41,7 @@ const brandStyle = {
   margin: '35px 0 50px',
 };
 
-function Redirect({ to }) {
-  const router = useRouter();
-
-  useEffect(() => {
-    router.push(to);
-  }, [to]);
-
-  return null;
-}
-
 export default function AdminLayout({ children }) {
-  const { user, isLoading } = useUser();
-
-  if (!user || user.email !== process.env.ADMIN_EMAIL) {
-    return (
-      <>
-        {isLoading && null}
-        <Redirect to="/" />
-      </>
-    );
-  }
-
   function clearLocalStorage() {
     // eslint-disable-next-line no-undef
     localStorage.clear();

--- a/app/components/Customer/CustomerLayout.jsx
+++ b/app/components/Customer/CustomerLayout.jsx
@@ -1,6 +1,3 @@
-import { useUser } from '@auth0/nextjs-auth0';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
 import Nav from 'react-bootstrap/Nav';
 import Navbar from 'react-bootstrap/Nav';
 
@@ -43,28 +40,7 @@ const brandStyle = {
   margin: '35px 0 50px',
 };
 
-function Redirect({ to }) {
-  const router = useRouter();
-
-  useEffect(() => {
-    router.push(to);
-  }, [to]);
-
-  return null;
-}
-
 export default function CustomerLayout({ children }) {
-  const { user, isLoading } = useUser();
-
-  if (!user || user.email === process.env.ADMIN_EMAIL) {
-    return (
-      <>
-        {isLoading && null}
-        <Redirect to="/" />
-      </>
-    );
-  }
-
   function clearLocalStorage() {
     // eslint-disable-next-line no-undef
     localStorage.clear();


### PR DESCRIPTION
This change enables Admin to view `/admin-settings`, and User to view `/settings`.
It prevents the page from loading for a split-second if the user isn't authorized to view the page.

- Replaces Auth0's `useUser()` with `localStorage.getItem('userEmail')` to determine logged in user.
- Updated how Layout is wrapped around components.